### PR TITLE
Reduce layout shift for images

### DIFF
--- a/mask-border.js
+++ b/mask-border.js
@@ -1,0 +1,38 @@
+let Declaration = require('../declaration')
+
+class MaskBorder extends Declaration {
+  /**
+   * Return property name by final spec
+   */
+  normalize() {
+    return this.name.replace('box-image', 'border')
+  }
+
+  /**
+   * Return flex property for 2012 spec
+   */
+  prefixed(prop, prefix) {
+    let result = super.prefixed(prop, prefix)
+    if (prefix === '-webkit-') {
+      result = result.replace('border', 'box-image')
+    }
+    return result
+  }
+}
+
+MaskBorder.names = [
+  'mask-border',
+  'mask-border-source',
+  'mask-border-slice',
+  'mask-border-width',
+  'mask-border-outset',
+  'mask-border-repeat',
+  'mask-box-image',
+  'mask-box-image-source',
+  'mask-box-image-slice',
+  'mask-box-image-width',
+  'mask-box-image-outset',
+  'mask-box-image-repeat'
+]
+
+module.exports = MaskBorder


### PR DESCRIPTION
Prevents cumulative layout shift by reserving intrinsic space for images. Adds width/height attributes and a fallback aspect-ratio CSS rule for responsive images to ensure stable layout during load.